### PR TITLE
Update GitHub Actions workflow to deploy via SFTP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: SFTP Deploy to GoDaddy
 
 on:
   push:
@@ -6,18 +6,22 @@ on:
       - production
 
 jobs:
-  ftp-deploy:
-    name: Upload via FTP
+  deploy:
+    name: Upload via SFTP
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repo
+      - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: FTP Deploy
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.4
+      - name: Deploy files over SFTP
+        uses: appleboy/scp-action@v0.1.7
         with:
-          server: ${{ secrets.FTP_HOST }}
-          username: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          server-dir: ${{ secrets.FTP_TARGET_DIR }}
+          host: ${{ secrets.SFTP_HOST }}
+          username: ${{ secrets.SFTP_USERNAME }}
+          password: ${{ secrets.SFTP_PASSWORD }}
+          port: ${{ secrets.SFTP_PORT }}
+          source: "."
+          target: ${{ secrets.SFTP_TARGET }}
+          rm: false
+          strip_components: 1


### PR DESCRIPTION
This pull request updates the deployment workflow to switch from FTP to SFTP for enhanced security and compatibility. The changes include renaming the workflow, modifying job configurations, and replacing the FTP deployment action with an SFTP deployment action.

### Deployment Workflow Updates:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L1-R27): Renamed the workflow from "Deploy" to "SFTP Deploy to GoDaddy" for clarity.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L1-R27): Replaced the FTP deployment job (`SamKirkland/FTP-Deploy-Action`) with an SFTP deployment job (`appleboy/scp-action`) to use secure file transfer protocol. Updated configuration parameters to include `host`, `port`, `source`, and `target` for SFTP.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L1-R27): Changed job name from "Upload via FTP" to "Upload via SFTP" and updated step descriptions for consistency.