### PR TITLE
Update GitHub Actions workflow name and steps for SFTP deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: SFTP Deploy to GoDaddy
+name: Deploy to GoDaddy via SFTP with SSH
 
 on:
   push:
@@ -7,21 +7,20 @@ on:
 
 jobs:
   deploy:
-    name: Upload via SFTP
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Deploy files over SFTP
+      - name: Upload via SFTP
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.SFTP_HOST }}
           username: ${{ secrets.SFTP_USERNAME }}
-          password: ${{ secrets.SFTP_PASSWORD }}
+          key: ${{ secrets.SFTP_PRIVATE_KEY }}
           port: ${{ secrets.SFTP_PORT }}
           source: "."
           target: ${{ secrets.SFTP_TARGET }}
-          rm: false
           strip_components: 1
+          rm: false


### PR DESCRIPTION
This pull request updates the `.github/workflows/deploy.yml` file to improve clarity and enhance security by switching from password-based authentication to SSH key-based authentication for SFTP deployment.

### Workflow improvements:
* Renamed the workflow from "SFTP Deploy to GoDaddy" to "Deploy to GoDaddy via SFTP with SSH" for better clarity. (`[.github/workflows/deploy.ymlL1-R1](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L1-R1)`)
* Updated job and step names to be more descriptive, such as changing "Checkout code" to "Checkout repo" and "Deploy files over SFTP" to "Upload via SFTP." (`[.github/workflows/deploy.ymlL10-R26](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L10-R26)`)

### Security enhancements:
* Replaced the use of `secrets.SFTP_PASSWORD` with `secrets.SFTP_PRIVATE_KEY` for SFTP authentication, switching from password-based to SSH key-based authentication for improved security. (`[.github/workflows/deploy.ymlL10-R26](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L10-R26)`)